### PR TITLE
Fix endless loop

### DIFF
--- a/alcher.simba
+++ b/alcher.simba
@@ -306,6 +306,12 @@ begin
 
   if Inventory.IsOpen then
   begin
+    if ToStr(AlchItem) = '' then
+      Self.SetupAlchItems;
+
+    if not Inventory.FindItem(AlchItem) then
+      Exit(EAlcherState.END_SCRIPT2);
+      
     if MainScreen.IsUpText('Alchemy ->') then
       Exit(EAlcherState.CHOOSE_ITEM);
 


### PR DESCRIPTION
Script repeats below once items run out and terminates on failsafe
    if MainScreen.IsUpText('Alchemy ->') then
      Exit(EAlcherState.CHOOSE_ITEM);