### PR TITLE
Add food restocking and healing at bank functionality

### DIFF
--- a/wasp_pickpocketer.simba
+++ b/wasp_pickpocketer.simba
@@ -22,6 +22,7 @@ type
     WITHDRAW_FOOD,
     WITHDRAW_NECKLACES,
     CLOSE_INTERFACE,
+    HEAL_TO_FULL,
 
     OPEN_CHAT,
     CHANGE_CHAT_FILTER,
@@ -63,9 +64,10 @@ type
     LasPickPosition: TPoint;
 
     //run variables (to be used while the script is running)
-    RenderDisabled, HasNeck, FreshNeck, RedemptionEnabled: Boolean;
+    RenderDisabled, HasNeck, FreshNeck, RedemptionEnabled, RestockFoodAfterHeal,
+    BankHealFinished: Boolean;
 
-    CoinPouchLimit, MaxHit, NextHeal, VeilAttempts: Int32;
+    CoinPouchLimit, MaxHit, NextHeal, VeilAttempts, FoodPointsAfterWithdraw: Int32;
   end;
 
 
@@ -311,7 +313,7 @@ begin
     else if Equipment.ContainsItem('Thieving cape(t)') then
       Self.RogueEquipment += 'Thieving cape(t)'
     else if Equipment.ContainsItem('Max cape') then
-      Self.RogueEquipment += 'Max cape'; 
+      Self.RogueEquipment += 'Max cape';
 
     //Lava staves for shadow veil spell
     if Equipment.ContainsItem('Lava battlestaff') then
@@ -521,6 +523,75 @@ begin
     Self.NextHeal := 0; //This will be reset when TThiever.IsLowHP() is called.
 end;
 
+function TThiever.HealToFull(): Boolean;
+var
+  currentHP, maxHP, oldHP: Int32;
+begin
+  maxHP := Stats.GetLevel(ERSSkill.HITPOINTS);
+  if maxHP < 1 then
+    Exit;
+
+  currentHP := Minimap.GetHPLevel();
+  Result := currentHP >= maxHP;
+
+  while (currentHP < maxHP) and Inventory.ContainsConsumable(ERSConsumable.FOOD) do
+  begin
+    oldHP := currentHP;
+    if not Inventory.Consume(ERSConsumable.FOOD) then
+      Break;
+
+    currentHP := Minimap.GetHPLevel();
+    if currentHP <= oldHP then
+      Break;
+
+    Result := currentHP >= maxHP;
+  end;
+
+  if currentHP >= maxHP then
+    Self.NextHeal := 0; //This will be reset when TThiever.IsLowHP() is called.
+
+  Self.BankHealFinished := True;
+  Result := True;
+end;
+
+function TThiever.WithdrawFood(): Boolean;
+var
+  oldAmount, oldMinInvPoints: Int32;
+begin
+  if Self.RestockFoodAfterHeal and
+     (Self.FoodPointsAfterWithdraw > 0) and
+     (Inventory.CountPoints(ERSConsumable.FOOD) < Self.FoodPointsAfterWithdraw) then
+  begin
+    oldAmount := FoodHandler.Amount;
+    oldMinInvPoints := FoodHandler.MinInvPoints;
+
+    FoodHandler.Amount := 0;
+    FoodHandler.MinInvPoints := Self.FoodPointsAfterWithdraw;
+    Result := Bank.WithdrawConsumable(ERSConsumable.FOOD);
+
+    FoodHandler.Amount := oldAmount;
+    FoodHandler.MinInvPoints := oldMinInvPoints;
+    Result := WaitUntil(Inventory.CountPoints(ERSConsumable.FOOD) >= Self.FoodPointsAfterWithdraw, 300, 3000);
+
+    if Result then
+    begin
+      Self.RestockFoodAfterHeal := False;
+      Self.BankHealFinished := False;
+      Self.FoodPointsAfterWithdraw := 0;
+    end;
+
+    Exit;
+  end;
+
+  Result := Bank.WithdrawConsumable(ERSConsumable.FOOD);
+  if Result then
+  begin
+    Self.FoodPointsAfterWithdraw := Inventory.CountPoints(ERSConsumable.FOOD);
+    Self.RestockFoodAfterHeal := True;
+    Self.BankHealFinished := False;
+  end;
+end;
+
 function TThiever.EquipNeck(): Boolean;
 begin
   if Result := Inventory.ClickItem(Necklace) then Wait(300, 400);
@@ -690,11 +761,33 @@ begin
         Exit(EThieverState.DEPOSIT_LOOT);
       if Inventory.CountItem(Necklace) < NeckAmount then
         Exit(EThieverState.WITHDRAW_NECKLACES);
+      if Self.RestockFoodAfterHeal and
+         (Inventory.CountPoints(ERSConsumable.FOOD) < Self.FoodPointsAfterWithdraw) then
+        Exit(EThieverState.WITHDRAW_FOOD);
       if not Inventory.HasEnoughConsumable(ERSConsumable.FOOD) then
         Exit(EThieverState.WITHDRAW_FOOD);
     end;
 
     Exit(EThieverState.CLOSE_INTERFACE);
+  end;
+
+  if Self.RestockFoodAfterHeal then
+  begin
+    if not Self.BankHealFinished and
+       (Minimap.GetHPLevel() < Stats.GetLevel(ERSSkill.HITPOINTS)) then
+    begin
+      if Inventory.ContainsConsumable(ERSConsumable.FOOD) then
+        Exit(EThieverState.HEAL_TO_FULL);
+
+      Exit(EThieverState.OPEN_BANK);
+    end;
+
+    if Inventory.CountPoints(ERSConsumable.FOOD) < Self.FoodPointsAfterWithdraw then
+      Exit(EThieverState.OPEN_BANK);
+
+    Self.RestockFoodAfterHeal := False;
+    Self.BankHealFinished := False;
+    Self.FoodPointsAfterWithdraw := 0;
   end;
 
   if Self.IsPouchFull() then
@@ -762,9 +855,10 @@ begin
     case Self.State of
       OPEN_BANK: Bank.WalkOpen();
       DEPOSIT_LOOT: Self.Deposit();
-      WITHDRAW_FOOD: Bank.WithdrawConsumable(ERSConsumable.FOOD);
+      WITHDRAW_FOOD: Self.WithdrawFood();
       WITHDRAW_NECKLACES: Self.WithdrawNecks();
       CLOSE_INTERFACE: RSInterface.Close();
+      HEAL_TO_FULL: Self.HealToFull();
 
       OPEN_CHAT: ChatButtons.Open(ERSChatButton.GAME_CHAT);
       CHANGE_CHAT_FILTER: ChatButtons.ChangeState(ERSChatButton.GAME_CHAT, ERSChatButtonState.ENABLED);


### PR DESCRIPTION
This modifies the current operation of the banking functionality of pickpocketer. Currently, once you run out of food and go to bank, it withdraws the food but then runs right back to the pickpocketing area without first eating and restocking, essentially leaving you with a mostly depleted food supply by the time you refill on hp even though you just got done banking. This was especially inefficient for longer bank runs. 
I've now changed the logic so that after withdrawing the food it will proceed to eat it right there at the bank booth to max, then it will reopen the bank interface and only refill however much food was consumed before going back to its pickpocketing state.